### PR TITLE
Update River encode handling of optional fields to compare values using

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ v0.1.1 (2023-08-25)
 
 - Fix typos and expand README for documentation.
 
-- Update River encode handling of optional fields to compare values using
+- `token/builder`: Update River encode handling of optional fields to compare values using
   DeepEqual even if they don't implement Equal when deciding if the field
   should be included. (@erikbaranowski)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ v0.1.1 (2023-08-25)
 
 - Fix typos and expand README for documentation.
 
+- Update River encode handling of optional fields to compare values using
+  DeepEqual even if they don't implement Equal when deciding if the field
+  should be included. (@erikbaranowski)
+
 v0.1.0 (2023-08-25)
 -------------------
 

--- a/token/builder/builder.go
+++ b/token/builder/builder.go
@@ -191,7 +191,7 @@ func (b *Body) encodeFields(rv reflect.Value) {
 		// zero value. Checking for both fields being zero handles the case where
 		// an empty and nil map are being compared (which are not equal, but are
 		// both zero values).
-		matchesDefault := fieldVal.Comparable() && reflect.DeepEqual(fieldVal.Interface(), fieldValDefault.Interface())
+		matchesDefault := reflect.DeepEqual(fieldVal.Interface(), fieldValDefault.Interface())
 		isZero := fieldValDefault.IsZero() && fieldVal.IsZero()
 
 		if field.IsOptional() && (matchesDefault || isZero) {


### PR DESCRIPTION
  DeepEqual even if they don't implement Equal when deciding if the field
  should be included.