### PR TITLE
vm: allow accessing non-existent keys in objects using `[]`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ Main (unreleased)
   objects, rather than returning an error. For example, `{}["foo"]` now returns
   `null`. (@rfratto)
 
+### Bugfixes
+
+- Fix a bug where indexing an object with a non-string key would generate a
+  type error informing users to supply a `number` instead of the actually
+  expected `string` type. (@rfratto)
+
 v0.2.0 (2023-10-20)
 -------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ internal API changes are not present.
 Main (unreleased)
 -----------------
 
+### Enhancements
+
+- Allow the `[]` operator to return `null` when accessing non-existant keys in
+  objects, rather than returning an error. For example, `{}["foo"]` now returns
+  `null`. (@rfratto)
+
 v0.2.0 (2023-10-20)
 -------------------
 

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -403,17 +403,13 @@ func (vm *Evaluator) evaluateExpr(scope *Scope, assoc map[value.Value]ast.Node, 
 		case value.TypeObject:
 			// Objects are indexed with a string.
 			if idx.Type() != value.TypeString {
-				return value.Null, value.TypeError{Value: idx, Expected: value.TypeNumber}
+				return value.Null, value.TypeError{Value: idx, Expected: value.TypeString}
 			}
 
 			field, ok := val.Key(idx.Text())
 			if !ok {
-				return value.Null, diag.Diagnostic{
-					Severity: diag.SeverityLevelError,
-					StartPos: ast.StartPos(expr.Index).Position(),
-					EndPos:   ast.EndPos(expr.Index).Position(),
-					Message:  fmt.Sprintf("field %q does not exist", idx.Text()),
-				}
+				// If a key doesn't exist in an object accessed with [], return null.
+				return value.Null, nil
 			}
 			return field, nil
 

--- a/vm/vm_test.go
+++ b/vm/vm_test.go
@@ -122,6 +122,7 @@ func TestVM_Evaluate(t *testing.T) {
 		// Access
 		{`{ a = 15 }.a`, int(15)},
 		{`{ a = { b = 12 } }.a.b`, int(12)},
+		{`{}["foo"]`, nil},
 
 		// Indexing
 		{`[0, 1, 2][1]`, int(1)},
@@ -146,7 +147,14 @@ func TestVM_Evaluate(t *testing.T) {
 
 			eval := vm.New(expr)
 
-			vPtr := reflect.New(reflect.TypeOf(tc.expect)).Interface()
+			var vPtr any
+			if tc.expect != nil {
+				vPtr = reflect.New(reflect.TypeOf(tc.expect)).Interface()
+			} else {
+				// Create a new any pointer.
+				vPtr = reflect.New(reflect.TypeOf((*any)(nil)).Elem()).Interface()
+			}
+
 			require.NoError(t, eval.Evaluate(scope, vPtr))
 
 			actual := reflect.ValueOf(vPtr).Elem().Interface()


### PR DESCRIPTION
Previously, `{}["foo"]` would return an error for the key "foo" not existing in the object.

This commit loosens that restriction, and now returns `null` for any key that does not exist in an object when the `[]` operator is used to access the key.

The `.` operator will still return an error for non-existent keys, such as `{}.foo`.

Related to grafana/agent#5615.