### PR TITLE
Add support for raw map[string]any type to riverjson encoding.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ internal API changes are not present.
 Main (unreleased)
 -----------------
 
+### Features
+
+- Add support for raw map[string]any type to riverjson encoding. (@wildum)
+
 v0.3.0 (2023-10-26)
 -------------------
 

--- a/encoding/riverjson/riverjson.go
+++ b/encoding/riverjson/riverjson.go
@@ -17,7 +17,7 @@ import (
 var goRiverDefaulter = reflect.TypeOf((*value.Defaulter)(nil)).Elem()
 
 // MarshalBody marshals the provided Go value to a JSON representation of
-// River. MarshalBody panics if not given a struct with River tags.
+// River. MarshalBody panics if not given a struct with River tags or a map[string]any.
 func MarshalBody(val interface{}) ([]byte, error) {
 	rv := reflect.ValueOf(val)
 	return json.Marshal(encodeStructAsBody(rv))
@@ -33,30 +33,50 @@ func encodeStructAsBody(rv reflect.Value) jsonBody {
 
 	if rv.Kind() == reflect.Invalid {
 		return []jsonStatement{}
-	} else if rv.Kind() != reflect.Struct {
-		panic(fmt.Sprintf("river/encoding/riverjson: can only encode struct values to bodies, got %s", rv.Kind()))
-	}
-
-	fields := rivertags.Get(rv.Type())
-	defaults := reflect.New(rv.Type()).Elem()
-	if defaults.CanAddr() && defaults.Addr().Type().Implements(goRiverDefaulter) {
-		defaults.Addr().Interface().(value.Defaulter).SetToDefault()
 	}
 
 	body := []jsonStatement{}
 
-	for _, field := range fields {
-		fieldVal := reflectutil.Get(rv, field)
-		fieldValDefault := reflectutil.Get(defaults, field)
-
-		var isEqual = fieldVal.Comparable() && fieldVal.Equal(fieldValDefault)
-		var isZero = fieldValDefault.IsZero() && fieldVal.IsZero()
-
-		if field.IsOptional() && (isEqual || isZero) {
-			continue
+	switch rv.Kind() {
+	case reflect.Struct:
+		fields := rivertags.Get(rv.Type())
+		defaults := reflect.New(rv.Type()).Elem()
+		if defaults.CanAddr() && defaults.Addr().Type().Implements(goRiverDefaulter) {
+			defaults.Addr().Interface().(value.Defaulter).SetToDefault()
 		}
 
-		body = append(body, encodeFieldAsStatements(nil, field, fieldVal)...)
+		for _, field := range fields {
+			fieldVal := reflectutil.Get(rv, field)
+			fieldValDefault := reflectutil.Get(defaults, field)
+
+			isEqual := fieldVal.Comparable() && fieldVal.Equal(fieldValDefault)
+			isZero := fieldValDefault.IsZero() && fieldVal.IsZero()
+
+			if field.IsOptional() && (isEqual || isZero) {
+				continue
+			}
+
+			body = append(body, encodeFieldAsStatements(nil, field, fieldVal)...)
+		}
+
+	case reflect.Map:
+		if rv.Type().Key().Kind() != reflect.String {
+			panic("river/encoding/riverjson: unsupported map type; expected map[string]T, got " + rv.Type().String())
+		}
+
+		iter := rv.MapRange()
+		for iter.Next() {
+			mapKey, mapValue := iter.Key(), iter.Value()
+
+			body = append(body, jsonAttr{
+				Name:  mapKey.String(),
+				Type:  "attr",
+				Value: buildJSONValue(value.FromRaw(mapValue)),
+			})
+		}
+
+	default:
+		panic(fmt.Sprintf("river/encoding/riverjson: can only encode struct or map values to bodies, got %s", rv.Kind()))
 	}
 
 	return body

--- a/encoding/riverjson/riverjson.go
+++ b/encoding/riverjson/riverjson.go
@@ -76,7 +76,7 @@ func encodeStructAsBody(rv reflect.Value) jsonBody {
 		}
 
 	default:
-		panic(fmt.Sprintf("river/encoding/riverjson: can only encode struct or map values to bodies, got %s", rv.Kind()))
+		panic(fmt.Sprintf("river/encoding/riverjson: can only encode struct or map[string]T values to bodies, got %s", rv.Kind()))
 	}
 
 	return body

--- a/encoding/riverjson/riverjson.go
+++ b/encoding/riverjson/riverjson.go
@@ -26,16 +26,16 @@ func MarshalBody(val interface{}) ([]byte, error) {
 func encodeStructAsBody(rv reflect.Value) jsonBody {
 	for rv.Kind() == reflect.Pointer {
 		if rv.IsNil() {
-			return []jsonStatement{}
+			return jsonBody{}
 		}
 		rv = rv.Elem()
 	}
 
 	if rv.Kind() == reflect.Invalid {
-		return []jsonStatement{}
+		return jsonBody{}
 	}
 
-	body := []jsonStatement{}
+	body := jsonBody{}
 
 	switch rv.Kind() {
 	case reflect.Struct:

--- a/encoding/riverjson/riverjson_test.go
+++ b/encoding/riverjson/riverjson_test.go
@@ -335,18 +335,27 @@ func TestMapBlocks(t *testing.T) {
 }
 
 func TestRawMap(t *testing.T) {
-	val := map[string]any{"field": "value", "anotherField": 3}
+	val := map[string]any{"field": "value"}
 
 	expect := `[{
-		"name": "field",
-		"type": "attr",
-		"value": { "type": "string", "value": "value" }
-	},
-	{
-		"name": "anotherField",
-		"type": "attr",
-		"value": { "type": "number", "value": 3 }
-	}]`
+        "name": "field",
+        "type": "attr",
+        "value": { "type": "string", "value": "value" }
+    }]`
+
+	bb, err := riverjson.MarshalBody(val)
+	require.NoError(t, err)
+	require.JSONEq(t, expect, string(bb))
+}
+
+func TestRawMap_Capsule(t *testing.T) {
+	val := map[string]any{"capsule": rivertypes.Secret("foo")}
+
+	expect := `[{
+        "name": "capsule",
+        "type": "attr",
+        "value": { "type": "capsule", "value": "(secret)" }
+    }]`
 
 	bb, err := riverjson.MarshalBody(val)
 	require.NoError(t, err)

--- a/encoding/riverjson/riverjson_test.go
+++ b/encoding/riverjson/riverjson_test.go
@@ -333,3 +333,22 @@ func TestMapBlocks(t *testing.T) {
 	require.NoError(t, err)
 	require.JSONEq(t, expect, string(bb))
 }
+
+func TestRawMap(t *testing.T) {
+	val := map[string]any{"field": "value", "anotherField": 3}
+
+	expect := `[{
+		"name": "field",
+		"type": "attr",
+		"value": { "type": "string", "value": "value" }
+	},
+	{
+		"name": "anotherField",
+		"type": "attr",
+		"value": { "type": "number", "value": 3 }
+	}]`
+
+	bb, err := riverjson.MarshalBody(val)
+	require.NoError(t, err)
+	require.JSONEq(t, expect, string(bb))
+}


### PR DESCRIPTION
With the [new modules](https://github.com/grafana/agent/issues/5547) for the Grafana Agent we got rid of the "Exports" struct and decided to export the map directly. This makes the custom components behave more like builtin components because there is no need for the extra "exports" field in the config.

Some of the component info like arguments, exports and debugInfo are encoded from river to json to be displayed in the UI. The encoding expects the content to be wrapped inside of a struct and panics otherwise.

With this change, users have now the possibility to encode their river map[string]any to json without wrapping it inside of a struct.

This change was missed when the support decoding blocks into maps was added in https://github.com/grafana/agent/pull/3232.

#Fixes https://github.com/grafana/agent/issues/3244
