### PR TITLE
Add yaml_decode function to stdlib

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Main (unreleased)
 ### Features
 
 - Add support for raw map[string]any type to riverjson encoding. (@wildum)
+- Add yaml_decode function to stdlib. (@djcode)
 
 v0.3.0 (2023-10-26)
 -------------------

--- a/internal/stdlib/stdlib.go
+++ b/internal/stdlib/stdlib.go
@@ -11,6 +11,8 @@ import (
 	"github.com/grafana/river/rivertypes"
 	"github.com/ohler55/ojg/jp"
 	"github.com/ohler55/ojg/oj"
+
+	"gopkg.in/yaml.v3"
 )
 
 // Identifiers holds a list of stdlib identifiers by name. All interface{}
@@ -77,6 +79,15 @@ var Identifiers = map[string]interface{}{
 	"json_decode": func(in string) (interface{}, error) {
 		var res interface{}
 		err := json.Unmarshal([]byte(in), &res)
+		if err != nil {
+			return nil, err
+		}
+		return res, nil
+	},
+
+	"yaml_decode": func(in string) (interface{}, error) {
+		var res interface{}
+		err := yaml.Unmarshal([]byte(in), &res)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
River/Grafana Agent has the ability to parse json via the json_decode function.
This PR adds the same functionality for yaml files.